### PR TITLE
Created NicknameComplete for issue #6

### DIFF
--- a/Floe.UI/ChatControl/ChatControl.xaml
+++ b/Floe.UI/ChatControl/ChatControl.xaml
@@ -213,7 +213,7 @@
 		</Border>
 		<Border DockPanel.Dock="Bottom" BorderBrush="{Binding Source={x:Static local:App.Settings}, Path=Current.Colors.WindowForeground, Mode=OneWay}"
 				BorderThickness="0,1,0,1" SnapsToDevicePixels="True">
-			<TextBox Name="txtInput" SnapsToDevicePixels="True" KeyDown="txtInput_KeyDown" SelectionChanged="txtInput_SelectionChanged"
+			<TextBox Name="txtInput" SnapsToDevicePixels="True" KeyDown="txtInput_KeyDown"
 				 Foreground="{Binding Source={x:Static local:App.Settings}, Path=Current.Colors.Edit, Mode=OneWay}"
 				 FontFamily="{Binding Source={x:Static local:App.Settings}, Path=Current.Formatting.FontFamily, Mode=OneWay}"
 				 FontSize="{Binding Source={x:Static local:App.Settings}, Path=Current.Formatting.FontSize, Mode=OneWay}"

--- a/Floe.UI/ChatControl/ChatControl.xaml.cs
+++ b/Floe.UI/ChatControl/ChatControl.xaml.cs
@@ -250,7 +250,6 @@ namespace Floe.UI
 		{
 			txtInput.Text = text;
 			txtInput.SelectionStart = text.Length;
-			_nickCandidates = null;
 		}
 
 		private void SetTitle()

--- a/Floe.UI/ChatControl/ChatControl_Events.cs
+++ b/Floe.UI/ChatControl/ChatControl_Events.cs
@@ -778,11 +778,6 @@ namespace Floe.UI
             }
         }
 
-        private void txtInput_SelectionChanged(object sender, RoutedEventArgs e)
-        {
-            _nickCandidates = null;
-        }
-
         protected override void OnPreviewMouseRightButtonDown(MouseButtonEventArgs e)
         {
             this.SelectedLink = null;
@@ -862,7 +857,7 @@ namespace Floe.UI
                         if (this.IsChannel || this.IsNickname)
                         {
                             tabHit = true;
-                            tabData = DoNickCompletion(tabData);
+                            DoNickCompletion();
                         }
                         break;
                     default:
@@ -873,7 +868,7 @@ namespace Floe.UI
 
                 if (tabHit != true)
                 {
-                    tabData = Tuple.Create(0, "");
+                    _nicknameComplete = null;
                 }
             }
             else if (e.Key >= Key.A && e.Key <= Key.Z)

--- a/Floe.UI/ChatControl/ChatControl_NickList.cs
+++ b/Floe.UI/ChatControl/ChatControl_NickList.cs
@@ -9,8 +9,8 @@ namespace Floe.UI
 {
     public partial class ChatControl : ChatPage
     {
-        private string[] _nickCandidates;
         private NicknameList _nickList;
+        private NicknameComplete _nicknameComplete;
 
         public NicknameList Nicknames
         {
@@ -27,149 +27,19 @@ namespace Floe.UI
             return (nick.Length > 1 && (nick[0] == '@' || nick[0] == '+' || nick[0] == '%')) ? nick.Substring(1) : nick;
         }
 
-        private Tuple<int, int> findNickCharsFromCaret(bool expectingNick)
+        private void DoNickCompletion()
         {
-            int start = 0;
-            int end = 0;
-
-            if (txtInput.Text.Length > 0)
+            if(txtInput.CaretIndex == 0)
             {
-                // We're going to use start and end to define a selection of a possible nickname fragment
-                // in the txtInput field, centered around the input caret.
-                start = Math.Max(0, txtInput.CaretIndex - 1);
-                end = start < txtInput.Text.Length ? start + 1 : start;
-
-                // If we're hitting "tab" again to complete to another nick, we will expect either ": " or " " to 
-                // be following the actual range we want. Let's shift start and end accordingly.
-                if (expectingNick && (txtInput.Text.Length > 2 && start >= 2))
-                {
-                    if (string.Compare(": ", txtInput.Text.Substring(start-1, 2)) == 0)
-                    {
-                        start = start - 2;
-                        end = end - 1;
-                    }
-                    else if (string.Compare(" ", txtInput.Text.Substring(start, 1)) == 0)
-                    {
-                        start = start - 1;
-                    }
-                }
-                // Hunt backwards from start, testing each character in the text input for valid IRC nick characters.
-                while (start >= 0 && NicknameItem.IsNickChar(txtInput.Text[start]))
-                {
-                    start--;
-                }
-                start++;
-
-                // Hunt forwards from end, testing each character in the text input for valid IRC nick characters.
-                while (end < txtInput.Text.Length && NicknameItem.IsNickChar(txtInput.Text[end]))
-                {
-                    end++;
-                }
-            }
-            else
-            {
-                start = end = 0;
+                return;
             }
 
-            return Tuple.Create(start, end);
-        }
-
-        private string appendProperEnding(string nextNick, int start, int end, string totalText)
-        {
-            if (totalText.Length <=2 && !totalText.Contains(' '))
+            if (_nicknameComplete == null)
             {
-                nextNick += ": ";
-            }
-            else if (string.Compare(totalText.Substring(end-1, 2), ": ") == 0 ||
-                        !totalText.Contains(' '))
-            {
-                nextNick += ": ";
-            }
-            else
-            {
-                nextNick += " ";
-            }
-            return nextNick;
-        }
-
-        private Tuple<int, string> DoNickCompletion(Tuple<int, string> tabData)
-        {
-            int start = 0, end = 0;
-            int tabCount = tabData.Item1;
-            string originalString = tabData.Item2;
-            Tuple<int, int> result;
-            string completionString;
-
-            result = findNickCharsFromCaret(tabCount > 0);
-            start = result.Item1;
-            end = result.Item2;
-
-            if (originalString != "")
-            {
-                completionString = originalString;
-            }
-            else
-            {
-                completionString = txtInput.Text.Substring(start, end - start);
+                _nicknameComplete = new NicknameComplete(txtInput, _nickList);
             }
 
-            if (end - start > 0)
-            {
-                string nickPart = completionString;
-                string nextNick = null;
-                int candidateIndex = 0;
-                if (_nickCandidates == null)
-                {
-                    _nickCandidates = (from n in this.Nicknames
-                                       where n.Nickname.StartsWith(nickPart, StringComparison.InvariantCultureIgnoreCase)
-                                       orderby n.Nickname.ToLowerInvariant()
-                                       select n.Nickname).ToArray();
-                }
-
-                if (_nickCandidates.Length > 0)
-                {
-                    if (tabCount >= _nickCandidates.Length)
-                    {
-                        candidateIndex = tabCount % _nickCandidates.Length;
-                    }
-                    else
-                    {
-                        candidateIndex = tabCount;
-                    }
-                    nextNick = _nickCandidates[candidateIndex];
-                }
-                // If nextNick perfectly matches an existing nick and there's other nickCandidates, use the next candidate
-                // instead of this one.
-                for (int i = candidateIndex; i < _nickCandidates.Length; i++)
-                {
-                    if (string.Compare(_nickCandidates[i], nickPart, StringComparison.InvariantCulture) == 0)
-                    {
-                        nextNick = i < _nickCandidates.Length - 1 ? _nickCandidates[i + 1] : _nickCandidates[0];
-                        break;
-                    }
-                }
-
-                var keepNickCandidates = _nickCandidates;
-                if (nextNick != null)
-                {
-                    nextNick = appendProperEnding(nextNick, start, end, txtInput.Text); 
-                    txtInput.Text = txtInput.Text.Substring(0, start) + nextNick + txtInput.Text.Substring(end);
-                    txtInput.CaretIndex = start + nextNick.Length;
-                }
-                _nickCandidates = keepNickCandidates;
-            }
-            checked
-            {
-                try
-                {
-                    tabCount++;
-                }
-                catch (OverflowException)
-                {
-                    tabCount = 1;
-                }
-            }
-            return Tuple.Create(tabCount, completionString);
+            _nicknameComplete.getNextNick();
         }
     }
 }

--- a/Floe.UI/ChatControl/NicknameComplete.cs
+++ b/Floe.UI/ChatControl/NicknameComplete.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Controls;
+
+namespace Floe.UI
+{
+    class NicknameComplete
+    {
+        private string[] _nickCandidates;
+        private uint _tabCount;
+        private string _incompleteNick;
+        private int _incompleteNickStart;
+        private TextBox _txtInput;
+        private bool _nickAtBeginning;
+
+        public NicknameComplete(TextBox txtInput, NicknameList nickList)
+        {
+            _tabCount = 0;
+            _txtInput = txtInput;
+            _incompleteNick = initialInputParse();
+            _nickCandidates = (from n in nickList
+                               where n.Nickname.StartsWith(_incompleteNick, StringComparison.InvariantCultureIgnoreCase)
+                               orderby n.Nickname.ToLowerInvariant()
+                               select n.Nickname).ToArray();
+
+        }
+
+        public void getNextNick()
+        {
+            _tabCount++;
+            if (_nickCandidates.Length <= 0)
+            {
+                return;
+            }
+
+            if (_tabCount > _nickCandidates.Length)
+            {
+                _tabCount = 1;
+            }
+
+            string completeNick = _nickCandidates[_tabCount - 1];
+
+            if(_nickAtBeginning)
+            {
+                completeNick += ": ";
+            }
+            else
+            {
+                completeNick += " ";
+            }
+
+            _txtInput.Text = _txtInput.Text.Substring(0, _incompleteNickStart) + completeNick;
+            _txtInput.CaretIndex = _txtInput.Text.Length;
+            return;
+        }
+
+        private string initialInputParse()
+        {
+            int i = _txtInput.CaretIndex - 1;
+            char c = _txtInput.Text[i];
+            while ( c != ' ' && i > 0)
+            {
+                c = _txtInput.Text[--i];
+            }
+            if (i == 0)
+            {
+                _nickAtBeginning = true;
+                _incompleteNickStart = 0;
+            }
+            else if (_txtInput.Text[i-1] == ':')
+            {
+                _incompleteNickStart = i + 1;
+                _nickAtBeginning = true;
+            }
+            else
+            {
+                _incompleteNickStart = i+1;
+                _nickAtBeginning = false;
+            }
+            return _txtInput.Text.Substring(_incompleteNickStart, _txtInput.CaretIndex - _incompleteNickStart);
+        }
+    }
+}

--- a/Floe.UI/Floe.UI.csproj
+++ b/Floe.UI/Floe.UI.csproj
@@ -133,6 +133,7 @@
     <Compile Include="ChatControl\ChatControl_Events.cs" />
     <Compile Include="ChatControl\ChatControl_NickList.cs" />
     <Compile Include="ChatControl\ChatControl_Slap.cs" />
+    <Compile Include="ChatControl\NicknameComplete.cs" />
     <Compile Include="ChatControl\NicknameItem.cs" />
     <Compile Include="ChatControl\NicknameList.cs" />
     <Compile Include="ChatControl\NotifyState.cs" />


### PR DESCRIPTION
Original implementation of tab completion for nicknames had buffer issues according to #6 . By pulling out tab completion into its own object, memory can be managed more easily due to encapsulation.
